### PR TITLE
Test samples expect Groovy 2.0.6 to work.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
   // mandatory dependencies for using Spock
-  groovy "org.codehaus.groovy:groovy-all:2.0.5"
+  groovy "org.codehaus.groovy:groovy-all:2.0.6"
   testCompile "org.spockframework:spock-core:1.0-groovy-2.0-SNAPSHOT"
 
   // optional dependencies for using Spock


### PR DESCRIPTION
When running tests out-of-the-box, GroovyRuntimeException is encountered due to conflicting Groovy module versions.
