### PR TITLE
Upgrade Maven project to Spock 2.0-M3, also sync Spock dependency versions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,7 +76,7 @@ The Jars will be copied to `build/output/lib`. The comments in `build.gradle` ex
 * http://groovy-lang.org/[Groovy homepage]
 * http://maven.apache.org[Maven homepage]
 
-If you have any comments or questions, please direct them to the Spock discussion group. All feedback is appreciated!
+If you have any comments or questions, please direct them to the Spock discussion group. We appreciate all feedback!
 
 Happy spec'ing!
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,18 +15,19 @@ repositories {
 
 dependencies {
   // mandatory dependencies for using Spock
-  compile "org.codehaus.groovy:groovy-all:2.5.8"
-  testCompile platform("org.spockframework:spock-bom:2.0-M1-groovy-2.5")
+  compile "org.codehaus.groovy:groovy:2.5.12"
+  testCompile platform("org.spockframework:spock-bom:2.0-M3-groovy-2.5")
   testCompile "org.spockframework:spock-core"
-  testCompile "org.spockframework:spock-junit4" // you can remove this if your code does not rely on old JUnit 4 rules
+  testCompile "org.spockframework:spock-junit4"  // you can remove this if your code does not rely on old JUnit 4 rules
 
   // optional dependencies for using Spock
-  testCompile "org.hamcrest:hamcrest-core:1.3" // only necessary if Hamcrest matchers are used
-  testRuntime "net.bytebuddy:byte-buddy:1.9.3"          // allows mocking of classes (in addition to interfaces)
-  testRuntime "org.objenesis:objenesis:2.6"    // allows mocking of classes without default constructor (together with CGLIB)
+  testCompile "org.hamcrest:hamcrest-core:2.2"   // only necessary if Hamcrest matchers are used
+  testRuntime "net.bytebuddy:byte-buddy:1.10.10" // allows mocking of classes (in addition to interfaces)
+  testRuntime "org.objenesis:objenesis:3.1"      // allows mocking of classes without default constructor (together with ByteBuddy or CGLIB)
 
   // dependencies used by examples in this project
   testRuntime "com.h2database:h2:1.4.197"
+  compile "org.codehaus.groovy:groovy-sql:2.5.12"
 }
 
 // the remaining configuration is specific to this project, and is not required for using Spock

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
   // mandatory dependencies for using Spock
-  compile "org.codehaus.groovy:groovy:2.5.12"
+  compile "org.codehaus.groovy:groovy:2.5.13"
   testCompile platform("org.spockframework:spock-bom:2.0-M3-groovy-2.5")
   testCompile "org.spockframework:spock-core"
   testCompile "org.spockframework:spock-junit4"  // you can remove this if your code does not rely on old JUnit 4 rules
@@ -27,7 +27,7 @@ dependencies {
 
   // dependencies used by examples in this project
   testRuntime "com.h2database:h2:1.4.197"
-  compile "org.codehaus.groovy:groovy-sql:2.5.12"
+  compile "org.codehaus.groovy:groovy-sql:2.5.13"
 }
 
 // the remaining configuration is specific to this project, and is not required for using Spock

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <groovy.version>2.5.12</groovy.version>
   </properties>
 
   <build>
@@ -60,7 +61,7 @@
       <dependency>
         <groupId>org.spockframework</groupId>
         <artifactId>spock-bom</artifactId>
-        <version>2.0-M1-groovy-2.5</version>
+        <version>2.0-M3-groovy-2.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -83,24 +84,24 @@
     <dependency> <!-- use a specific Groovy version rather than the one specified by spock-core -->
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>2.5.8</version>
+      <version>${groovy.version}</version>
     </dependency>
     <dependency> <!-- enables mocking of classes (in addition to interfaces) -->
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.9.3</version>
+      <version>1.10.10</version>
       <scope>test</scope>
     </dependency>
-    <dependency> <!-- enables mocking of classes without default constructor (together with CGLIB) -->
+    <dependency> <!-- enables mocking of classes without default constructor (together with ByteBuddy or CGLIB) -->
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>2.6</version>
+      <version>3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency> <!-- only required if Hamcrest matchers are used -->
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <!-- Dependencies used by examples in this project (not required for using Spock) -->
@@ -108,6 +109,11 @@
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <version>1.4.197</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-sql</artifactId>
+      <version>${groovy.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <groovy.version>2.5.12</groovy.version>
+    <groovy.version>2.5.13</groovy.version>
   </properties>
 
   <build>

--- a/src/test/groovy/DataDrivenSpec.groovy
+++ b/src/test/groovy/DataDrivenSpec.groovy
@@ -16,7 +16,6 @@
 
 import spock.lang.*
 
-@Unroll
 class DataDrivenSpec extends Specification {
   def "maximum of two numbers"() {
     expect:

--- a/src/test/groovy/DatabaseDrivenSpec.groovy
+++ b/src/test/groovy/DatabaseDrivenSpec.groovy
@@ -28,7 +28,6 @@ class DatabaseDrivenSpec extends Specification {
     sql.execute("insert into maxdata values (1, 3, 7, 7), (2, 5, 4, 5), (3, 9, 9, 9), (4, 2, -3, 2)")
   }
 
-  @Unroll
   def "Maximum of #a and #b is #c"() {
     expect:
     Math.max(a, b) == c

--- a/src/test/groovy/DatabaseDrivenSpec.groovy
+++ b/src/test/groovy/DatabaseDrivenSpec.groovy
@@ -17,7 +17,6 @@
 import groovy.sql.Sql
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class DatabaseDrivenSpec extends Specification {
   @Shared sql = Sql.newInstance("jdbc:h2:mem:", "org.h2.Driver")

--- a/src/test/groovy/DatabaseDrivenSpec.groovy
+++ b/src/test/groovy/DatabaseDrivenSpec.groovy
@@ -17,17 +17,19 @@
 import groovy.sql.Sql
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class DatabaseDrivenSpec extends Specification {
   @Shared sql = Sql.newInstance("jdbc:h2:mem:", "org.h2.Driver")
-  
+
   // insert data (usually the database would already contain the data)
   def setupSpec() {
     sql.execute("create table maxdata (id int primary key, a int, b int, c int)")
-    sql.execute("insert into maxdata values (1, 3, 7, 7), (2, 5, 4, 5), (3, 9, 9, 9)")
+    sql.execute("insert into maxdata values (1, 3, 7, 7), (2, 5, 4, 5), (3, 9, 9, 9), (4, 2, -3, 2)")
   }
 
-  def "maximum of two numbers"() {
+  @Unroll
+  def "Maximum of #a and #b is #c"() {
     expect:
     Math.max(a, b) == c
 

--- a/src/test/groovy/IncludeExcludeExtensionSpec.groovy
+++ b/src/test/groovy/IncludeExcludeExtensionSpec.groovy
@@ -49,15 +49,18 @@ import spock.lang.Specification
 class IncludeExcludeExtensionSpec extends Specification {
   @Fast
   def "a fast method"() {
+    println "fast"
     expect: true
   }
 
   @Slow
   def "a slow method"() {
+    println "slow"
     expect: true
   }
 
   def "a neither fast nor slow method"() {
+    println "neither fast nor slow"
     expect: true
   }
 }


### PR DESCRIPTION
Now that Spock no longer depends on `groovy-all`, for the database test it was necessary to add `groovy-sql`.

**Please note** that I am a Maven user. I also upgraded the Gradle build configuration and quickly ran it. It looks okay, but I am a Gradle noob. So please review even more thoroughly than my Maven changes.

**Side note:** I upgraded Hamcrest Core to 2.2 because Spock 2.0-M3 uses it, but actually JUnit 4 still depends on Hamcrest 1.3, so there is a version conflict. I suggest to dependency-manage the version in this project. I did not in order to keep the POM simple for beginners, but actually it is not clean.